### PR TITLE
Security: Disable logging sensitive fields

### DIFF
--- a/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/DataSourcesLoader.java
+++ b/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/DataSourcesLoader.java
@@ -65,7 +65,7 @@ public class DataSourcesLoader {
      String className = dataSourceConfig.getClassName();
      Map<String, Object> properties = dataSourceConfig.getProperties();
      try {
-       LOG.info("Creating thirdeye datasource {} with properties '{}'", className, properties);
+       LOG.info("Creating thirdeye datasource {} ", className);
        Constructor<?> constructor = Class.forName(className).getConstructor(Map.class);
        ThirdEyeDataSource thirdeyeDataSource = (ThirdEyeDataSource) constructor.newInstance(properties);
        // use class simple name as key, this enforces that there cannot be more than one data source of the same type


### PR DESCRIPTION
## Description
`DatasourcesLoader.java` ends up logging sensitive fields like passwords etc. This PR disables logging these fields for security reasons. 
